### PR TITLE
use the :hook keyword with use-package example

### DIFF
--- a/README.org
+++ b/README.org
@@ -30,10 +30,10 @@ Install through melpa as =jest-test-mode=.
 To configure the project with =use-package=:
 
 #+begin_src elisp
-  (use-package jest-test-mode :ensure t :defer t :commands jest-test-mode :init
-    (add-hook 'typescript-mode-hook 'jest-test-mode)
-    (add-hook 'js-mode-hook 'jest-test-mode)
-    (add-hook 'typescript-tsx-mode-hook 'jest-test-mode))
+  (use-package jest-test-mode 
+    :ensure t 
+    :commands jest-test-mode
+    :hook (typescript-mode js-mode typescript-tsx-mode))
 #+end_src
 
 Manually:


### PR DESCRIPTION
Nice package! I updated the example for use-package to be a little more concise (and what I ended up adding to my `.emacs.d`)

`use-package` supports the [`:hook`][hooks] keyword as a shortcut for manually adding hooks inside an `:init` block. Also, since both it, and the `:commands` imply :defer, the explicit `:defer t` has been removed

[hooks]: https://github.com/jwiegley/use-package#hooks