### PR TITLE
Invoke specific tests rather than group when possible

### DIFF
--- a/jest-test-mode.el
+++ b/jest-test-mode.el
@@ -192,11 +192,11 @@ mode"
 (defun jest-test-example-at-point ()
   "Find the topmost describe block from where the cursor is and extract the name."
   (save-excursion
-    (re-search-backward "^describe")
-    (let ((text (thing-at-point 'line t)))
-      (string-match "describe(\\(.*\\)," text)
-      (when-let ((example (match-string 1 text)))
-        (substring example 1 -1)))))
+    (when (re-search-backward "^describe" nil t)
+      (let ((text (thing-at-point 'line t)))
+        (string-match "describe(\\(.*\\)," text)
+        (when-let ((example (match-string 1 text)))
+          (substring example 1 -1))))))
 
 (defun jest-test-update-last-test (command)
   "Update the last test COMMAND."

--- a/jest-test-mode.el
+++ b/jest-test-mode.el
@@ -194,7 +194,7 @@ mode"
   (save-excursion
     (re-search-backward "^describe")
     (let ((text (thing-at-point 'line t)))
-      (string-match "describe\(\\(.*\\)," text)
+      (string-match "describe(\\(.*\\)," text)
       (when-let ((example (match-string 1 text)))
         (substring example 1 -1)))))
 


### PR DESCRIPTION
Currently `jest-run-test-at-point` runs the current test group (`describe` block) rather than the specific test (`it` block).

It would be nice to be able to run the specific test rather than the group. This PR makes it so that `jest-run-test-at-point` will attempt to run the specific test when available, or the group otherwise.

It also fixes a bug by which running when the point is before any `describe` will result in a thrown error rather than a "test not found" message.

If you prefer to keep the current behavior of `jest-run-test-at-point` then we could add a new `jest-run-specific-test-at-point` command or similar.