### PR TITLE
Allow customizing the jest invocation

### DIFF
--- a/jest-test-mode.el
+++ b/jest-test-mode.el
@@ -75,6 +75,19 @@
   :type '(list)
   :group 'jest-test-mode)
 
+(defcustom jest-test-command-string
+  "npx %s jest %s %s"
+  "The command by which jest is run.
+
+Placeholders are:
+
+1. npx options (`jest-test-npx-options')
+2. Jest test options (`jest-test-options')
+3. The file name"
+  :initialize 'custom-initialize-default
+  :type 'string
+  :group 'jest-test-mode)
+
 (defvar jest-test-last-test-command
   nil
   "The last test command ran with.")
@@ -215,7 +228,7 @@ mode"
 ;;;###autoload
 (defun jest-test-command (filename)
   "Format test arguments for FILENAME."
-  (format "npx %s jest %s %s"
+  (format jest-test-command-string
           (mapconcat #'shell-quote-argument jest-test-npx-options " ")
           (mapconcat #'shell-quote-argument jest-test-options " ")
           filename))

--- a/jest-test-mode.el
+++ b/jest-test-mode.el
@@ -231,7 +231,9 @@ mode"
   (format jest-test-command-string
           (mapconcat #'shell-quote-argument jest-test-npx-options " ")
           (mapconcat #'shell-quote-argument jest-test-options " ")
-          filename))
+          (if (string-empty-p filename)
+              filename
+            (file-relative-name filename (jest-test-project-root filename)))))
 
 ;;; compilation-mode support
 


### PR DESCRIPTION
I am working on a project that is extremely complex and can only be tested reliably through Docker. To that end I find that I need:

- Completely custom invocation string
- The test file to be specified relative to the project root

There are probably cleaner ways to do this (especially the relativizing, where we recalculate the project root) but this was the best I could come up with without making much larger changes to the code.