### PR TITLE
Define a compilation-mode for jest-test

### DIFF
--- a/jest-test-mode.el
+++ b/jest-test-mode.el
@@ -266,11 +266,13 @@ Looks for  \'it\', \'test\' or \'describe\' from where the cursor is"
   (add-hook 'compilation-filter-hook 'jest-test-colorize-compilation-buffer nil t))
 
 (defun jest-test-colorize-compilation-buffer ()
+  "Colorize the compilation buffer."
   (ansi-color-apply-on-region compilation-filter-start (point)))
 
 (defconst jest-test-compilation-buffer-name-base "*jest-test-compilation*")
 
 (defun jest-test-compilation-buffer-name (&rest _)
+  "Return the name of a compilation buffer."
   jest-test-compilation-buffer-name-base)
 
 (defun jest-test-enable ()

--- a/jest-test-mode.el
+++ b/jest-test-mode.el
@@ -234,10 +234,11 @@ Looks for  \'it\', \'test\' or \'describe\' from where the cursor is"
   (jest-test-update-last-test command)
   (let ((comint-scroll-to-bottom-on-input t)
         (comint-scroll-to-bottom-on-output t)
-        (comint-process-echoes t))
+        (comint-process-echoes t)
+        (compilation-buffer-name-function 'jest-test-compilation-buffer-name))
     ;; TODO: figure out how to prevent <RET> from re-sending the old input
     ;; See https://stackoverflow.com/questions/51275228/avoid-accidental-execution-in-comint-mode
-    (compilation-start command t)))
+    (compile command 'jest-test-compilation-mode)))
 
 ;;;###autoload
 (defun jest-test-command (filename)
@@ -254,9 +255,23 @@ Looks for  \'it\', \'test\' or \'describe\' from where the cursor is"
 ;; Source: https://emacs.stackexchange.com/questions/27213/how-can-i-add-a-compilation-error-regex-for-node-js
 ;; Handle errors that match this:
 ;; at addSpecsToSuite (node_modules/jest-jasmine2/build/jasmine/Env.js:522:17)
-(add-to-list 'compilation-error-regexp-alist 'jest)
-(add-to-list 'compilation-error-regexp-alist-alist
-             '(jest "at [^ ]+ (\\(.+?\\):\\([[:digit:]]+\\):\\([[:digit:]]+\\)" 1 2 3))
+(defvar jest-test-compilation-error-regexp-alist-alist
+  '((jest "at [^ ]+ (\\(.+?\\):\\([[:digit:]]+\\):\\([[:digit:]]+\\)" 1 2 3)))
+
+(defvar jest-test-compilation-error-regexp-alist
+  (mapcar 'car jest-test-compilation-error-regexp-alist-alist))
+
+(define-compilation-mode jest-test-compilation-mode "Jest Compilation"
+  "Compilation mode for Jest output."
+  (add-hook 'compilation-filter-hook 'jest-test-colorize-compilation-buffer nil t))
+
+(defun jest-test-colorize-compilation-buffer ()
+  (ansi-color-apply-on-region compilation-filter-start (point)))
+
+(defconst jest-test-compilation-buffer-name-base "*jest-test-compilation*")
+
+(defun jest-test-compilation-buffer-name (&rest _)
+  jest-test-compilation-buffer-name-base)
 
 (defun jest-test-enable ()
   "Enable the jest test mode."


### PR DESCRIPTION
Hi! This is a small feature that defines a compilation mode to modify this buffer as per your needs. 

For example, in Doom Emacs this buffer can be configured like this:

```elisp
(set-popup-rule! "^\\*\\(jest-\\)?compilation" :size 0.3 :ttl nil :select t)
```

Here is how it looks in Doom Emacs:
<img width="948" alt="image" src="https://github.com/rymndhng/jest-test-mode/assets/1894248/2eb910b4-0daf-4a12-8184-3e6fc99f75f5">

Let me know what do you think about it. Thanks!